### PR TITLE
仮HeadManagerの作成、ProtoPlayerのCheraTypeをCharaTypeに改名、CharaTypeにNoneを追加

### DIFF
--- a/TD4_Game/HeadManager.cpp
+++ b/TD4_Game/HeadManager.cpp
@@ -1,1 +1,86 @@
 #include "HeadManager.h"
+#include"HageHead.h"
+#include"AfroHead.h"
+#include"LightHearHead.h"
+
+HeadManager::HeadManager()
+{
+}
+
+HeadManager::~HeadManager()
+{
+}
+
+void HeadManager::Initialize()
+{
+	RVector3 easeOffset(0, 0, 100.f);
+	int i = 0;
+	for (auto &ep : easepos) {
+		ep = easeOffset * float(i);
+		i++;
+	}
+
+	FirstSpawn();
+}
+
+void HeadManager::Update()
+{
+	//要素数がMAXよりも少ない場合増やす
+	if (heads.size() < HEAD_DISPLAY_MAX)
+	{
+		Head *ptr = HeadSpawn(HEAD_DISPLAY_MAX - 1);
+
+		heads.push_back(std::make_shared<Head>());
+		heads[HEAD_DISPLAY_MAX - 1].reset(ptr);
+		heads[HEAD_DISPLAY_MAX - 1]->Init();
+		heads[HEAD_DISPLAY_MAX - 1]->pos = easepos[HEAD_DISPLAY_MAX - 1];
+	}
+	//更新処理
+	for (auto &h : heads) {
+		h->Update();
+	}
+}
+
+void HeadManager::Draw()
+{
+	for (const auto &h : heads) { h->Draw(); }
+}
+
+void HeadManager::PopFront()
+{
+	heads.erase(heads.begin());
+	//先頭が変わるので属性も移動させておく
+	for (int i = 0; i < HEAD_DISPLAY_MAX - 1; i++) {
+		charaType[i] = charaType[i + 1];
+	}
+	charaType[HEAD_DISPLAY_MAX - 1] = None;
+}
+
+CheraType HeadManager::GetFrontType()
+{
+	return charaType[0];
+}
+
+void HeadManager::FirstSpawn()
+{
+	//5回スポーン、位置設定
+	for (int i = 0; i < HEAD_DISPLAY_MAX; i++) {
+
+		Head *ptr = HeadSpawn(i);
+
+		heads.push_back(std::make_shared<Head>());
+		heads[i].reset(ptr);
+		heads[i]->Init();
+		heads[i]->pos = easepos[i];
+	}
+}
+
+Head *HeadManager::HeadSpawn(const int arrayNum)
+{
+	Head *head;
+
+	//ランダムで頭を生成
+	head = new AfroHead();
+	charaType[arrayNum] = SkinHead;
+	return head;
+}

--- a/TD4_Game/HeadManager.h
+++ b/TD4_Game/HeadManager.h
@@ -1,7 +1,33 @@
 #pragma once
 #include "Head.h"
+#include "ProtoPlayer.h"
 
 class HeadManager
 {
+private:
+	//表示最大数
+	static const int HEAD_DISPLAY_MAX = 5;
+public:
+	HeadManager();
+	~HeadManager();
+	void Initialize();
+	void Update();
+	void Draw();
+	//先頭の人を消す
+	void PopFront();
+	//先頭の人が何かを判別する
+	CheraType GetFrontType();
+private:
+	//初回スポーン
+	void FirstSpawn();
+	/// スポーン管理
+	Head *HeadSpawn(const int arrayNum);
+private:
+	//頭コンテナ
+	std::vector<std::shared_ptr<Head>> heads;
+	//イージング用座標
+	std::array<RVector3, HEAD_DISPLAY_MAX> easepos;
+	//属性
+	std::array<CheraType, HEAD_DISPLAY_MAX> charaType;
 };
 

--- a/TD4_Game/ProtoPlayer.h
+++ b/TD4_Game/ProtoPlayer.h
@@ -9,7 +9,7 @@
 
 enum CheraType
 {
-	SkinHead, Thinning, Afro,
+	None,SkinHead, Thinning, Afro,
 };
 
 class ProtoPlayer


### PR DESCRIPTION
HeadManagerの中身
・GameManagerでやっていた処理
・先頭が何なのか確認する関数
・先頭を消す関数
・更新処理で指定した最大要素数より少ない場合追加するようにした
・HeadSpawnの一部変更した関数